### PR TITLE
docs: expand configuration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,11 @@ Key settings:
 - `CORS_ORIGINS`, `RATE_LIMIT_ENABLED`
 - **Change all secrets before production!**
 
+## Advanced Configuration
+
+See [docs/advanced-config.md](docs/advanced-config.md) for optional settings
+such as custom ports, TLS setup, and authentication tweaks.
+
 ---
 
 ## Authentication
@@ -180,6 +185,7 @@ Key settings:
 - [docs/architecture.md](docs/architecture.md): System diagram
 - [docs/biometric.md](docs/biometric.md): WebAuthn setup
 - [docs/security.md](docs/security.md): Security guide
+- [docs/advanced-config.md](docs/advanced-config.md): Optional settings
 - [pipelines.md](pipelines.md): Dev/test/deploy workflows
 
 ---
@@ -192,7 +198,9 @@ MIT
 
 ## Badges
 
-TODO(#issue): Add CI, coverage, and Docker Hub badges
+[![CI](https://img.shields.io/github/actions/workflow/status/rogu3bear/portus/ci.yml?branch=main)](https://github.com/rogu3bear/portus/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/codecov/c/github/rogu3bear/portus)](https://codecov.io/gh/rogu3bear/portus)
+[![Docker Pulls](https://img.shields.io/docker/pulls/rogu3bear/portus)](https://hub.docker.com/r/rogu3bear/portus)
 
 ---
 
@@ -204,10 +212,9 @@ TODO(#issue): Add CI, coverage, and Docker Hub badges
 
 ---
 
-## TODO
+## Roadmap
 
-- TODO(#issue): Add project badges
-- TODO(#issue): Complete frontend and backend test coverage
-- TODO(#issue): Document advanced configuration options
+- Expand frontend and backend test coverage
+- Document additional configuration options
 
 ---

--- a/docs/advanced-config.md
+++ b/docs/advanced-config.md
@@ -1,0 +1,26 @@
+# Advanced Configuration
+
+This document outlines optional settings for customizing a Portus deployment.
+
+## Override Ports
+
+- `API_PORT` - API server port
+- `UI_PORT` - React UI port
+- `DNS_PORT` - CoreDNS listening port
+- `ZORAXY_PORT` - Zoraxy proxy port
+
+## Enabling TLS
+
+Traefik can be configured to terminate TLS. Update `docker-compose.prod.yml` and
+provide certificates via volumes or an ACME provider.
+
+## Custom CoreDNS Zone
+
+Adjust `DNS_DOMAIN` and update `Corefile` to serve additional zones or records.
+
+## Authentication Settings
+
+- `AUTH_ENABLED` toggles login requirement.
+- `AUTH_SESSION_EXPIRY_MINUTES` controls session duration.
+
+Refer to `project_config.md` for full configuration reference.

--- a/project_config.md
+++ b/project_config.md
@@ -8,4 +8,8 @@ version_pins:
   - python: ">=3.8,<4.0"
   - pytest: "^7.0"
   - mypy: "^1.0"
-  # TODO(#issue): Pin versions for frontend dependencies
+  - react: "18.2.0"
+  - react-dom: "18.2.0"
+  - typescript: "5.3.3"
+  - vite: "6.3.5"
+  - tailwindcss: "3.4.1"

--- a/tests/test_webauthn.py
+++ b/tests/test_webauthn.py
@@ -1,0 +1,10 @@
+from fastapi.testclient import TestClient
+from backend.app.main import app
+
+client = TestClient(app)
+
+
+def test_webauthn_placeholder_unavailable():
+    resp = client.post("/auth/webauthn-placeholder")
+    assert resp.status_code == 501
+    assert resp.json()["detail"] == "FIDO2 library not installed; biometric auth unavailable"


### PR DESCRIPTION
## Summary
- add advanced configuration docs
- pin frontend versions in project_config.md
- add CI, coverage, and Docker badges
- reference advanced config in README
- add WebAuthn placeholder test

## Testing
- `ruff check backend/app`
- `pytest -q` *(fails: command not found)*
- `python -m pytest -q` *(fails: No module named pytest)*
