### PR TITLE
feat(auth): implement persistent WebAuthn credential store and full flows

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,12 +1,16 @@
 from datetime import datetime, timedelta
 import json
 import os
+import base64
+import pickle
 from fastapi import APIRouter, HTTPException, Request, Response
 from jose import jwt
 from passlib.context import CryptContext
 from pydantic import BaseModel
 
 from .settings import settings
+from .db import SessionLocal
+from . import models
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -85,10 +89,8 @@ def status_endpoint(request: Request):
     }
 
 
-# In-memory stores for WebAuthn demo data. These are reset on restart.
-# TODO(#127): replace with persistent storage in production
-WEBAUTHN_USERS: dict[str, bytes] = {}
-WEBAUTHN_CREDS: dict[str, list] = {}
+# In-memory state for WebAuthn challenges. Reset on restart.
+WEBAUTHN_STATE: dict[str, tuple] = {}
 WEBAUTHN_STATE: dict[str, tuple] = {}
 
 
@@ -111,14 +113,24 @@ def webauthn_begin(username: str):
         id=username.encode("utf-8"), name=username, display_name=username
     )
 
-    if username not in WEBAUTHN_CREDS:
-        registration_data, state = server.register_begin(user, credentials=[])
-        WEBAUTHN_STATE[username] = ("register", state, server)
-        return registration_data
+    db = SessionLocal()
+    try:
+        creds = (
+            db.query(models.WebAuthnCredential)
+            .filter(models.WebAuthnCredential.username == username)
+            .all()
+        )
+        cred_objs = [pickle.loads(c.credential_data) for c in creds]
+        if not cred_objs:
+            registration_data, state = server.register_begin(user, credentials=[])
+            WEBAUTHN_STATE[username] = ("register", state, server)
+            return registration_data
 
-    auth_data, state = server.authenticate_begin(WEBAUTHN_CREDS[username])
-    WEBAUTHN_STATE[username] = ("authenticate", state, server)
-    return auth_data
+        auth_data, state = server.authenticate_begin(cred_objs)
+        WEBAUTHN_STATE[username] = ("authenticate", state, server)
+        return auth_data
+    finally:
+        db.close()
 
 
 @router.post("/webauthn")
@@ -139,24 +151,46 @@ async def webauthn_complete(username: str, request: Request, response: Response)
     mode, state, server = WEBAUTHN_STATE.pop(username)
     data = await request.json()
 
-    if mode == "register":
-        attestation = server.register_complete(state, data)
-        WEBAUTHN_CREDS.setdefault(username, []).append(attestation.credential_data)
-        return {"status": "registered"}
+    db = SessionLocal()
+    try:
+        creds = (
+            db.query(models.WebAuthnCredential)
+            .filter(models.WebAuthnCredential.username == username)
+            .all()
+        )
+        cred_objs = [pickle.loads(c.credential_data) for c in creds]
 
-    # authenticate
-    server.authenticate_complete(state, WEBAUTHN_CREDS[username], data)
-    expiry = timedelta(minutes=settings.session_expiry_minutes)
-    token = jwt.encode({"sub": username, "exp": datetime.utcnow() + expiry}, settings.secret_key, algorithm=settings.algorithm)
-    response.set_cookie(
-        SESSION_COOKIE,
-        token,
-        max_age=int(expiry.total_seconds()),
-        httponly=True,
-        secure=True,  # keep strict security
-        samesite="strict",  # enforce cross-site request restrictions
-    )
-    return {"status": "authenticated"}
+        if mode == "register":
+            attestation = server.register_complete(state, data)
+            cred = models.WebAuthnCredential(
+                username=username,
+                credential_id=base64.b64encode(attestation.credential_data.credential_id).decode(),
+                credential_data=pickle.dumps(attestation.credential_data),
+                sign_count=attestation.auth_data.counter,
+            )
+            db.add(cred)
+            db.commit()
+            return {"status": "registered"}
+
+        # authenticate
+        server.authenticate_complete(state, cred_objs, data)
+        expiry = timedelta(minutes=settings.session_expiry_minutes)
+        token = jwt.encode(
+            {"sub": username, "exp": datetime.utcnow() + expiry},
+            settings.secret_key,
+            algorithm=settings.algorithm,
+        )
+        response.set_cookie(
+            SESSION_COOKIE,
+            token,
+            max_age=int(expiry.total_seconds()),
+            httponly=True,
+            secure=True,
+            samesite="strict",
+        )
+        return {"status": "authenticated"}
+    finally:
+        db.close()
 
 
 # Also provide a placeholder endpoint for compatibility
@@ -171,7 +205,6 @@ def webauthn_placeholder():
             status_code=501,
             detail="FIDO2 library not installed; biometric auth unavailable",
         )
-    # TODO(#128): Implement full WebAuthn registration and login flows
     rp = PublicKeyCredentialRpEntity("portus", "Portus")
     _ = Fido2Server(rp)
     return {"detail": "WebAuthn placeholder"}

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, DateTime
+from sqlalchemy import Column, Integer, String, DateTime, LargeBinary
 from sqlalchemy.sql import func
 from .db import Base
 
@@ -10,4 +10,17 @@ class Service(Base):
     host = Column(String)
     port = Column(Integer)
     proto = Column(String, default="http")
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+
+class WebAuthnCredential(Base):
+    """Persisted WebAuthn credential for biometric authentication."""
+
+    __tablename__ = "webauthn_credential"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, index=True, nullable=False)
+    credential_id = Column(String, unique=True, nullable=False)
+    credential_data = Column(LargeBinary, nullable=False)
+    sign_count = Column(Integer, default=0)
     created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/migrations/versions/0001_add_webauthn_credential.py
+++ b/migrations/versions/0001_add_webauthn_credential.py
@@ -1,0 +1,39 @@
+"""Add WebAuthn credential table
+
+Revision ID: 0001
+Revises: 
+Create Date: 2025-05-20
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Upgrade schema by creating webauthn_credential table."""
+    op.create_table(
+        "webauthn_credential",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("username", sa.String(), nullable=False),
+        sa.Column("credential_id", sa.String(), nullable=False, unique=True),
+        sa.Column("credential_data", sa.LargeBinary(), nullable=False),
+        sa.Column("sign_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "ix_webauthn_credential_username", "webauthn_credential", ["username"]
+    )
+
+
+def downgrade() -> None:
+    """Drop webauthn_credential table."""
+    op.drop_table("webauthn_credential")

--- a/tests/test_webauthn.py
+++ b/tests/test_webauthn.py
@@ -8,3 +8,8 @@ def test_webauthn_placeholder_unavailable():
     resp = client.post("/auth/webauthn-placeholder")
     assert resp.status_code == 501
     assert resp.json()["detail"] == "FIDO2 library not installed; biometric auth unavailable"
+
+
+def test_webauthn_endpoints_unavailable():
+    resp = client.get("/auth/webauthn", params={"username": "alice"})
+    assert resp.status_code == 501


### PR DESCRIPTION
## Summary
- add `WebAuthnCredential` model for persistent storage
- migrate database to create `webauthn_credential` table
- implement registration and authentication using stored credentials
- update WebAuthn tests for optional library behavior

## Testing
- `ruff check backend/app tests`
- `pytest -q` *(fails: command not found)*