### PR TITLE
Add CI badges and frontend test scaffolds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,22 +5,32 @@ on:
   pull_request:
     branches: [ main ]
 jobs:
-  build:
+  ci:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [18]
-    defaults:
-      run:
-        working-directory: ui
     steps:
       - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install backend dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt
+          pip install ruff pytest
+      - name: Backend lint
+        run: ruff check backend/app
+      - name: Backend tests
+        run: pytest
+
       - uses: pnpm/action-setup@v2
         with:
           version: 8
-      - name: Install dependencies
-        run: cd ui && pnpm install --frozen-lockfile
-      - name: Lint
-        run: cd ui && pnpm lint
-      - name: Test
-        run: cd ui && pnpm test
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile --dir ui
+      - name: Frontend lint
+        run: pnpm --dir ui lint
+      - name: Frontend typecheck
+        run: pnpm --dir ui typecheck
+      - name: Frontend tests
+        run: pnpm --dir ui test

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Portus: LAN Orchestrator
 
-**Portus** is a local DNS and reverse-proxy orchestration system for managing services on a LAN.  
-It integrates FastAPI, React, CoreDNS, and Zoraxy for seamless service discovery, routing, and management.
+[![CI](https://github.com/rogu3bear/portus/actions/workflows/ci.yml/badge.svg)](https://github.com/rogu3bear/portus/actions/workflows/ci.yml)
+[![Docker Pulls](https://img.shields.io/docker/pulls/rogu3bear/portus)](https://hub.docker.com/r/rogu3bear/portus) <!-- TODO(#200): verify link once published -->
 
----
+**Portus** is a local DNS and reverse-proxy orchestration system for managing services on a LAN.
+It integrates FastAPI, React, CoreDNS, and Zoraxy for seamless service discovery, routing, and management.
 
 ## Features
 
@@ -197,15 +198,6 @@ MIT
 
 ---
 
-## Badges
-
-TODO(#123): Add CI, coverage, and Docker Hub badges
-=======
-[![CI](https://img.shields.io/github/actions/workflow/status/rogu3bear/portus/ci.yml?branch=main)](https://github.com/rogu3bear/portus/actions/workflows/ci.yml)
-[![Coverage](https://img.shields.io/codecov/c/github/rogu3bear/portus)](https://codecov.io/gh/rogu3bear/portus)
-[![Docker Pulls](https://img.shields.io/docker/pulls/rogu3bear/portus)](https://hub.docker.com/r/rogu3bear/portus)
-
----
 
 ## Acknowledgements
 
@@ -220,8 +212,5 @@ TODO(#123): Add CI, coverage, and Docker Hub badges
 - TODO(#123): Add project badges
 - TODO(#124): Complete frontend and backend test coverage
 - TODO(#125): Document advanced configuration options
-=======
-- Expand frontend and backend test coverage
-- Document additional configuration options
 
 ---

--- a/project_config.md
+++ b/project_config.md
@@ -8,10 +8,11 @@ version_pins:
   - python: ">=3.8,<4.0"
   - pytest: "^7.0"
   - mypy: "^1.0"
-  # TODO(#126): Pin versions for frontend dependencies
-=======
   - react: "18.2.0"
   - react-dom: "18.2.0"
   - typescript: "5.3.3"
   - vite: "6.3.5"
   - tailwindcss: "3.4.1"
+  - tailwind-merge: "2.2.1"
+  - class-variance-authority: "0.7.0"
+  - shadcn-ui: "0.0.0" # local components pinned to repo version

--- a/ui/__tests__/MappingEditor.test.tsx
+++ b/ui/__tests__/MappingEditor.test.tsx
@@ -1,0 +1,7 @@
+import { render } from '@testing-library/react';
+import { MappingEditor } from '../src/components/mappings/mapping-editor';
+
+test('renders MappingEditor', () => {
+  const mapping = { id: 1, domain: 'example.com', aliases: [], path: '/', ip: '1.1.1.1', port: 80 };
+  render(<MappingEditor mapping={mapping} onSave={() => {}} onCancel={() => {}} />);
+});

--- a/ui/__tests__/PortMapper.test.tsx
+++ b/ui/__tests__/PortMapper.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+import { MappingProvider } from '../src/providers/mapping-provider';
+import { PortMapper } from '../src/components/port-mapper/port-mapper';
+
+test('renders PortMapper', () => {
+  render(
+    <MappingProvider>
+      <PortMapper />
+    </MappingProvider>
+  );
+});


### PR DESCRIPTION
## Summary
- add CI and Docker Hub badges to README
- clean up README conflict markers
- pin frontend dependency versions in project_config
- run backend and frontend lint/test steps in GitHub Actions
- scaffold MappingEditor and PortMapper tests

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`
- `ruff check backend/app`
- `pytest` *(fails: command not found)*